### PR TITLE
Serialize error stack and loglevel field

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,30 +75,41 @@ will produce a log like:
 ## Errors serializer
 When you pass an error to the logger the possible scenarios are:
 
-- the Error is passed as `mergingObject` (first param) and the log has already a `message` (second param). In this case the logger add fields `"error_message": Error.message` and `"error_stack": Error.stack` to the `mergingObject` and the log message is printed in the `message` field
+- the Error is passed as `mergingObject` (first param) and the log has already a `message` (second param). In this case the logger add field `"error_message": Error.message` and [common error fields](#common-error-fields) to the `mergingObject` and the log message is printed in the `message` field
 ```js
 logger.error(new Error("This is an error"), "Error with log message");
 ```
 will produce a log like:
 ```
-{"level":50,"time":1567688722065,"type":"test","context":"app","error_message":"This is an error","error_stack":"Error: This is an error...","loglevel":"ERROR","message":"Error with log message","v":1}
+{"level":50,"time":1567688722065,"type":"test","context":"app","error_message":"This is an error","error_stack":"Error: This is an error...","error_file":"...","error_line":"...","loglevel":"ERROR","message":"Error with log message","v":1}
 ```
 
-- the Error is passed as `mergingObject` (first param) and the log has not a `message` (second param). In this case the logger add field `"error_stack": Error.stack` to the `mergingObject` and use the `Error.message` as log `message`
+- the Error is passed as `mergingObject` (first param) and the log has not a `message` (second param). In this case the logger add [common error fields](#common-error-fields) to the `mergingObject` and use the `Error.message` as log `message`
 ```js
 logger.error(new Error("Error without log message");
 ```
 will produce a log like:
 ```
-{"level":50,"time":1567688853208,"type":"test","context":"app","error_stack":"Error: Error without log message...","loglevel":"ERROR","message":"Error without log message","v":1}
+{"level":50,"time":1567688853208,"type":"test","context":"app","error_stack":"Error: Error without log message...","error_file":"...","error_line":"...","loglevel":"ERROR","message":"Error without log message","v":1}
 ```
 
 
-- the Error is passed as log `message` (second param). In this case the logger add field `"error_stack": Error.stack` to the mergingObject and use the `Error.message` as log `message`
+- the Error is passed as log `message` (second param). In this case the logger add [common error fields](#common-error-fields) to the mergingObject and use the `Error.message` as log `message`
 ```js
 logger.error({ "a": "b" }, new Error("Error as log message"));
 ```
 will produce a log like:
 ```
-"level":50,"time":1567689070052,"type":"test","context":"app","a":"b","error_stack":"Error: Error as log message...","loglevel":"ERROR","message":"Error as log message","v":1}
+"level":50,"time":1567689070052,"type":"test","context":"app","a":"b","error_stack":"Error: Error as log message...","error_file":"...","error_line":"...","loglevel":"ERROR","message":"Error as log message","v":1}
 ```
+
+### Common error fields
+```js
+{
+    error_stack: "error stack trace",
+    error_file: "path of the file",
+    error_line: "number of the line"
+}
+```
+
+

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ It's possible to create 2 different instances of the logger:
 - `Application Logger`: this is an instance of `Pino Logger`, initialized with `Spreaker's base options`, with a custom serializer that take care of stringify objects and array and transforming other types into string before log.
 - `Access Logger`: this is an instance of `Pino Logger`, initialized with `Spreaker's base options`.
 
+Both the loggers provide 2 common functions:
+- Add `loglevel` field to each log to have a string version of the log level
+- Errors serializer that take care of set the correct error fields in the logs
+
 
 ## Install package
 
@@ -21,7 +25,7 @@ const { createLogger } = require("@spreaker/logger");
 // Mandatory properties are: 
 // - `type` (name of application is using the logger)
 // - `context` (type of logger to create: "app" or "access")
-// Default logLevel if not passed is "info".
+// Minimum level of log enabled; if not passed is "info".
 const logger = createLogger({ type: "test", context: "app"}, "info");
 
 // Use the logger as a simple `Pino` child instance.
@@ -46,7 +50,7 @@ logger.info(
 ```
 will produce a log like:
 ```
-{"level":30,"time":1566908680683,"type":"test","context":"app","object":"{\"b\":123}","string":"c","number":"321","array":"[\"a\",1,[\"subarray\"]]","message":"Stringify log","v":1}
+{"level":30,"time":1566908680683,"type":"test","context":"app","object":"{\"b\":123}","string":"c","number":"321","array":"[\"a\",1,[\"subarray\"]]","message":"Stringify log","loglevel":"INFO","v":1}
 ```
 
 ### Access logger
@@ -65,6 +69,36 @@ logger.info(
 ```
 will produce a log like:
 ```
-{"level":30,"time":1566908953080,"type":"test","context":"access","object":{"b":123},"string":"c","number":321,"array":["a",1,["subarray"]],"message":"Don't stringify log","v":1}
+{"level":30,"time":1566908953080,"type":"test","context":"access","object":{"b":123},"string":"c","number":321,"array":["a",1,["subarray"]],"message":"Don't stringify log","loglevel":"INFO","v":1}
 ```
 
+## Errors serializer
+When you pass an error to the logger the possible scenarios are:
+
+- the Error is passed as `mergingObject` (first param) and the log has already a `message` (second param). In this case the logger add fields `"error_message": Error.message` and `"error_stack": Error.stack` to the `mergingObject` and the log message is printed in the `message` field
+```js
+logger.error(new Error("This is an error"), "Error with log message");
+```
+will produce a log like:
+```
+{"level":50,"time":1567688722065,"type":"test","context":"app","error_message":"This is an error","error_stack":"Error: This is an error...","loglevel":"ERROR","message":"Error with log message","v":1}
+```
+
+- the Error is passed as `mergingObject` (first param) and the log has not a `message` (second param). In this case the logger add field `"error_stack": Error.stack` to the `mergingObject` and use the `Error.message` as log `message`
+```js
+logger.error(new Error("Error without log message");
+```
+will produce a log like:
+```
+{"level":50,"time":1567688853208,"type":"test","context":"app","error_stack":"Error: Error without log message...","loglevel":"ERROR","message":"Error without log message","v":1}
+```
+
+
+- the Error is passed as log `message` (second param). In this case the logger add field `"error_stack": Error.stack` to the mergingObject and use the `Error.message` as log `message`
+```js
+logger.error({ "a": "b" }, new Error("Error as log message"));
+```
+will produce a log like:
+```
+"level":50,"time":1567689070052,"type":"test","context":"app","a":"b","error_stack":"Error: Error as log message...","loglevel":"ERROR","message":"Error as log message","v":1}
+```

--- a/index.js
+++ b/index.js
@@ -46,7 +46,9 @@ const createLogger = (props, minLoglevel) => {
             if(prop.toString() === "Symbol(pino.write)"){
                 return function () {
                     serializeError(arguments);
-                    serializeLogLevel(this.levels, arguments);
+                    if (props.context === "app") {
+                        serializeLogLevel(this.levels, arguments);
+                    }
                     target[prop].apply(this, arguments);
                 }
             }

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ const createLogger = (props, minLoglevel) => {
                 return function () {
                     serializeError(arguments);
                     if (props.context === "app") {
-                        serializeLogLevel(this.levels, arguments);
+                        serializeLogLevel(arguments);
                     }
                     target[prop].apply(this, arguments);
                 }

--- a/index.js
+++ b/index.js
@@ -29,7 +29,13 @@ const createLogger = (props, minLoglevel) => {
         level: minLoglevel ? minLoglevel.toLowerCase() : "info"
     }
 
-    // Add the custom serializers for application logger
+    /**
+     * Add the serializeToString for application logger
+     * We don't do this inside the Proxy because we want
+     * to be able to stringify all the fields, included
+     * the ones passed in the initialization that are not
+     * available in the pino.write
+     */ 
     if (props.context === "app") {
         options.serializers = serializers;
     }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
+/* jshint strict: false */
 const pino = require("pino");
 const { getCustomSerializers } = require("./utils/serializers");
+const { getLevelAsString } = require("./utils/levels");
 
 /**
  * Replace the standard serializer to be able to transform each log
@@ -34,7 +36,24 @@ const createLogger = (props, level) => {
 
     // Add the custom serializers based on the context
     options.serializers = getSerializers(props);
-    return pino(options).child(props);
+
+    const customPino = new Proxy(pino(options), {
+        get: function (target, prop) {
+            // intercept the 'write' fnc to be able to add the loglevel
+            if(prop.toString() === "Symbol(pino.write)"){
+                return function () {
+                    if (!arguments[0]) {
+                        arguments[0] = {}
+                    }
+                    arguments[0].loglevel = getLevelAsString(this.levels, arguments[2]);
+                    target[prop].apply(this, arguments);
+                }
+            }
+            return target[prop];
+        }
+    });
+
+    return customPino.child(props);
 };
 
 module.exports = {

--- a/index_spec.js
+++ b/index_spec.js
@@ -103,99 +103,119 @@ describe("Logger", () => {
         });
     });
 
-    describe("application logger", () => {
-        it("should log the initial properties passed", (done) => {
-            spyOn(process.stdout,"write").and.callFake(log => {
-                expect(log).toContain(
-                    '"type":"test","context":"app","test":"initial_properties"'
-                );
-                done();
+    ["parent", "child"].forEach(type => {
+        describe(`${type} application logger`, () => {
+            const getLogger = () => {
+                let logger = createLogger({ type: "test", context: "app"});
+                if (type === "child") {
+                    logger = logger.child({});
+                }
+                return logger;
+            }
+
+            it("should log the initial properties passed", (done) => {
+                spyOn(process.stdout,"write").and.callFake(log => {
+                    expect(log).toContain(
+                        '"type":"test","context":"app","test":"initial_properties"'
+                    );
+                    done();
+                });
+                const logger = getLogger();
+                logger.info({"test":"initial_properties"}, "Initial properties");
             });
-            const logger = createLogger({ type: "test", context: "app"});
-            logger.info({"test":"initial_properties"}, "Initial properties");
-        });
-        it("should not transform fields in the whitelist", (done) => {
-            spyOn(process.stdout,"write").and.callFake(log => {
-                expect(log).toContain(
-                    '"test":"whitelist","time":123,"pid":321'
-                );
-                done();
+            it("should not transform fields in the whitelist", (done) => {
+                spyOn(process.stdout,"write").and.callFake(log => {
+                    expect(log).toContain(
+                        '"test":"whitelist","time":123,"pid":321'
+                    );
+                    done();
+                });
+                const logger = getLogger();
+                logger.info({"test":"whitelist","time":123,"pid":321}, "Don't transform whitelist");
             });
-            const logger = createLogger({ type: "test", context: "app"});
-            logger.info({"test":"whitelist","time":123,"pid":321}, "Don't transform whitelist");
-        });
-        it("should stringify objects or array and transform other types into string before log INFO", (done) => {
-            spyOn(process.stdout,"write").and.callFake(log => {
-                expect(log).toContain(
-                    '"test":"stringify_info","object":"{\\\"b\\\":123}","string":"c","number":"321","array":"[\\\"a\\\",1,[\\\"subarray\\\"]]"'
-                );
-                done();
+            it("should stringify objects or array and transform other types into string before log INFO", (done) => {
+                spyOn(process.stdout,"write").and.callFake(log => {
+                    expect(log).toContain(
+                        '"test":"stringify_info","object":"{\\\"b\\\":123}","string":"c","number":"321","array":"[\\\"a\\\",1,[\\\"subarray\\\"]]"'
+                    );
+                    done();
+                });
+                const logger = getLogger();
+                logger.info({"test":"stringify_info","object":{"b":123},"string":"c","number":321,"array":["a",1,["subarray"]]}, "Stringify log");
             });
-            const logger = createLogger({ type: "test", context: "app"});
-            logger.info({"test":"stringify_info","object":{"b":123},"string":"c","number":321,"array":["a",1,["subarray"]]}, "Stringify log");
-        });
-        it("should stringify objects or array and transform other types into string before log WARN", (done) => {
-            spyOn(process.stdout,"write").and.callFake(log => {
-                expect(log).toContain(
-                    '"test":"stringify_warn","object":"{\\\"b\\\":123}","string":"c","number":"321","array":"[\\\"a\\\",1,[\\\"subarray\\\"]]"'
-                );
-                done();
+            it("should stringify objects or array and transform other types into string before log WARN", (done) => {
+                spyOn(process.stdout,"write").and.callFake(log => {
+                    expect(log).toContain(
+                        '"test":"stringify_warn","object":"{\\\"b\\\":123}","string":"c","number":"321","array":"[\\\"a\\\",1,[\\\"subarray\\\"]]"'
+                    );
+                    done();
+                });
+                const logger = getLogger();
+                logger.warn({"test":"stringify_warn","object":{"b":123},"string":"c","number":321,"array":["a",1,["subarray"]]}, "Stringify log");
             });
-            const logger = createLogger({ type: "test", context: "app"});
-            logger.warn({"test":"stringify_warn","object":{"b":123},"string":"c","number":321,"array":["a",1,["subarray"]]}, "Stringify log");
-        });
-        it("should transform null or boolean fields into string", (done) => {
-            spyOn(process.stdout,"write").and.callFake(log => {
-                expect(log).toContain(
-                    '"test":"stringify_null","a":"null","b":"true"'
-                );
-                done();
+            it("should transform null or boolean fields into string", (done) => {
+                spyOn(process.stdout,"write").and.callFake(log => {
+                    expect(log).toContain(
+                        '"test":"stringify_null","a":"null","b":"true"'
+                    );
+                    done();
+                });
+                const logger = getLogger();
+                logger.warn({"test":"stringify_null","a": null, "b": true}, "Transform null or boolean");
             });
-            const logger = createLogger({ type: "test", context: "app"});
-            logger.warn({"test":"stringify_null","a": null, "b": true}, "Transform null or boolean");
-        });
-        it("should stringify functions", (done) => {
-            spyOn(process.stdout,"write").and.callFake(log => {
-                expect(log).toContain(
-                    '"test":"stringify_functions","function":"function () {return true}"'
-                );
-                done();
+            it("should stringify functions", (done) => {
+                spyOn(process.stdout,"write").and.callFake(log => {
+                    expect(log).toContain(
+                        '"test":"stringify_functions","function":"function () {return true}"'
+                    );
+                    done();
+                });
+                const logger = getLogger();
+                logger.warn({"test":"stringify_functions","function": function () {return true}}, "Stringify functions");
             });
-            const logger = createLogger({ type: "test", context: "app"});
-            logger.warn({"test":"stringify_functions","function": function () {return true}}, "Stringify functions");
         });
     });
 
-    describe("access logger", () => {
-        it("should log the initial properties passed", (done) => {
-            spyOn(process.stdout,"write").and.callFake(log => {
-                expect(log).toContain(
-                    '"type":"test","context":"access","test":"access_initial_properties"'
-                );
-                done();
+    ["parent", "child"].forEach(type => {
+        describe(`${type} access logger`, () => {
+            const getLogger = () => {
+                let logger = createLogger({ type: "test", context: "access"});
+                if (type === "child") {
+                    logger = logger.child({});
+                }
+                return logger;
+            }
+
+            it("should log the initial properties passed", (done) => {
+                spyOn(process.stdout,"write").and.callFake(log => {
+                    expect(log).toContain(
+                        '"type":"test","context":"access","test":"access_initial_properties"'
+                    );
+                    done();
+                });
+                const logger = getLogger();
+                logger.info({"test":"access_initial_properties"}, "Initial properties");
             });
-            const logger = createLogger({ type: "test", context: "access"});
-            logger.info({"test":"access_initial_properties"}, "Initial properties");
-        });
-        it("should not stringify objects or array and not transform other types into string before log INFO", (done) => {
-            spyOn(process.stdout,"write").and.callFake(log => {
-                expect(log).toContain(
-                    '"test":"not_stringify_info","object":{\"b\":123},"string":"c","number":321,"array":[\"a\",1,[\"subarray\"]]'
-                );
-                done();
+            it("should not stringify objects or array and not transform other types into string before log INFO", (done) => {
+                spyOn(process.stdout,"write").and.callFake(log => {
+                    expect(log).toContain(
+                        '"test":"not_stringify_info","object":{\"b\":123},"string":"c","number":321,"array":[\"a\",1,[\"subarray\"]]'
+                    );
+                    done();
+                });
+                const logger = getLogger();
+                logger.info({"test":"not_stringify_info","object":{"b":123},"string":"c","number":321,"array":["a",1,["subarray"]]}, "Don't stringify log");
             });
-            const logger = createLogger({ type: "test", context: "access"});
-            logger.info({"test":"not_stringify_info","object":{"b":123},"string":"c","number":321,"array":["a",1,["subarray"]]}, "Don't stringify log");
-        });
-        it("should not stringify objects or array and not transform other types into string before log WARN", (done) => {
-            spyOn(process.stdout,"write").and.callFake(log => {
-                expect(log).toContain(
-                    '"test":"not_stringify_warn","object":{\"b\":123},"string":"c","number":321,"array":[\"a\",1,[\"subarray\"]]'
-                );
-                done();
+            it("should not stringify objects or array and not transform other types into string before log WARN", (done) => {
+                spyOn(process.stdout,"write").and.callFake(log => {
+                    expect(log).toContain(
+                        '"test":"not_stringify_warn","object":{\"b\":123},"string":"c","number":321,"array":[\"a\",1,[\"subarray\"]]'
+                    );
+                    done();
+                });
+                const logger = getLogger();
+                logger.warn({"test":"not_stringify_warn","object":{"b":123},"string":"c","number":321,"array":["a",1,["subarray"]]}, "Don't stringify log");
             });
-            const logger = createLogger({ type: "test", context: "access"});
-            logger.warn({"test":"not_stringify_warn","object":{"b":123},"string":"c","number":321,"array":["a",1,["subarray"]]}, "Don't stringify log");
         });
-    })
+    });
 });

--- a/index_spec.js
+++ b/index_spec.js
@@ -4,11 +4,13 @@ describe("Logger", () => {
 
     ["app","access"].forEach(context => {
         describe(`serialize Errors for ${context} logger`, () => {
-            it("should add error_stack and error_message if log message is present", (done) => {
+            it("should add common error fields and error_message if log message is present", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain('"message":"Error with log message"');
                     expect(log).toContain('"error_stack":"Error: This is an error');
                     expect(log).toContain('"error_message":"This is an error');
+                    expect(log).toContain('"error_file"');
+                    expect(log).toContain('"error_line"');
                     expect(log).not.toContain('"stack"');
                     done();
                 });
@@ -16,10 +18,12 @@ describe("Logger", () => {
                 logger.error(new Error("This is an error"), "Error with log message");
             });
 
-            it("should add error_stack and use Error.message as message if log message is not present", (done) => {
+            it("should add common error fields and use Error.message as message if log message is not present", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain('"message":"Error without log message"');
                     expect(log).toContain('"error_stack":"Error: Error without log message');
+                    expect(log).toContain('"error_file"');
+                    expect(log).toContain('"error_line"');
                     expect(log).not.toContain('"error_message"');
                     expect(log).not.toContain('"stack"');
                     done();
@@ -28,11 +32,13 @@ describe("Logger", () => {
                 logger.error(new Error("Error without log message"));
             });
 
-            it("should add error_stack and use Error.message as message if log message is the Error", (done) => {
+            it("should add common error fields and use Error.message as message if log message is the Error", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain('"a":"b"');
                     expect(log).toContain('"message":"Error as log message"');
                     expect(log).toContain('"error_stack":"Error: Error as log message');
+                    expect(log).toContain('"error_file"');
+                    expect(log).toContain('"error_line"');
                     expect(log).not.toContain('"error_message"');
                     expect(log).not.toContain('"stack"');
                     done();
@@ -45,6 +51,8 @@ describe("Logger", () => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain('"message":"Error of child logger"');
                     expect(log).toContain('"error_stack":"Error: This is an error');
+                    expect(log).toContain('"error_file"');
+                    expect(log).toContain('"error_line"');
                     expect(log).toContain('"error_message":"This is an error');
                     expect(log).not.toContain('"stack"');
                     done();

--- a/index_spec.js
+++ b/index_spec.js
@@ -136,7 +136,7 @@ describe("Logger", () => {
             it("should add the correct loglevel string if no mergingObject is passed", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain(
-                        `"type":"test","context":"app","loglevel":"INFO","message":"Loglevel no mergingObject"`
+                        '"type":"test","context":"app","loglevel":"INFO","message":"Loglevel no mergingObject"'
                     );
                     done();
                 });
@@ -146,7 +146,7 @@ describe("Logger", () => {
             it("should add the correct loglevel string if mergingObject is passed", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain(
-                        `"type":"test","context":"app","a":"b","loglevel":"WARN","message":"Loglevel with mergingObject"`
+                        '"type":"test","context":"app","a":"b","loglevel":"WARN","message":"Loglevel with mergingObject"'
                     );
                     done();
                 });
@@ -156,7 +156,7 @@ describe("Logger", () => {
             it("should add the correct loglevel string if we are logging an error message", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain(
-                        `"type":"test","context":"app","error_stack":"Error: Loglevel with error`
+                        '"type":"test","context":"app","error_stack":"Error: Loglevel with error'
                     );
                     expect(log).toContain(
                         '"loglevel":"ERROR","message":"Loglevel with error"'
@@ -165,6 +165,16 @@ describe("Logger", () => {
                 });
                 const logger = createLogger({ type: "test", context: "app" });
                 logger.error(new Error("Loglevel with error"));
+            });
+            it("should add loglevel = DEBUG for trace logs", (done) => {
+                spyOn(process.stdout,"write").and.callFake(log => {
+                    expect(log).toContain(
+                        '"type":"test","context":"app","loglevel":"DEBUG","message":"Replace trace with debug"'
+                    );
+                    done();
+                });
+                const logger = createLogger({ type: "test", context: "app" }, "trace");
+                logger.trace("Replace trace with debug");
             });
         });
     });

--- a/index_spec.js
+++ b/index_spec.js
@@ -63,54 +63,6 @@ describe("Logger", () => {
         });
     });
 
-    ["app","access"].forEach(context => {
-        describe(`serialize loglevel field for ${context} logger`, () => {
-            it("should add the correct loglevel string if no mergingObject is passed", (done) => {
-                spyOn(process.stdout,"write").and.callFake(log => {
-                    expect(log).toContain(
-                        `"type":"test","context":"${context}","loglevel":"INFO","message":"Loglevel no mergingObject"`
-                    );
-                    done();
-                });
-                const logger = createLogger({ type: "test", context});
-                logger.info("Loglevel no mergingObject");
-            });
-            it("should add the correct loglevel string if mergingObject is passed", (done) => {
-                spyOn(process.stdout,"write").and.callFake(log => {
-                    expect(log).toContain(
-                        `"type":"test","context":"${context}","a":"b","loglevel":"WARN","message":"Loglevel with mergingObject"`
-                    );
-                    done();
-                });
-                const logger = createLogger({ type: "test", context });
-                logger.warn({ "a": "b" }, "Loglevel with mergingObject");
-            });
-            it("should add the correct loglevel string if we are logging an error message", (done) => {
-                spyOn(process.stdout,"write").and.callFake(log => {
-                    expect(log).toContain(
-                        `"type":"test","context":"${context}","error_stack":"Error: Loglevel with error`
-                    );
-                    expect(log).toContain(
-                        '"loglevel":"ERROR","message":"Loglevel with error"'
-                    );
-                    done();
-                });
-                const logger = createLogger({ type: "test", context });
-                logger.error(new Error("Loglevel with error"));
-            });
-            it("should add the correct loglevel string for child logger", (done) => {
-                spyOn(process.stdout,"write").and.callFake(log => {
-                    expect(log).toContain(
-                        `"type":"test","context":"${context}","child":"child property","loglevel":"INFO","message":"Loglevel with child"`
-                    );
-                    done();
-                });
-                const logger = createLogger({ type: "test", context }).child({ "child": "child property" });
-                logger.info("Loglevel with child");
-            });
-        });
-    });
-
     ["parent", "child"].forEach(type => {
         describe(`${type} application logger`, () => {
             const getLogger = () => {
@@ -181,6 +133,39 @@ describe("Logger", () => {
                 const logger = getLogger();
                 logger.warn({"test":"stringify_functions","function": function () {return true}}, "Stringify functions");
             });
+            it("should add the correct loglevel string if no mergingObject is passed", (done) => {
+                spyOn(process.stdout,"write").and.callFake(log => {
+                    expect(log).toContain(
+                        `"type":"test","context":"app","loglevel":"INFO","message":"Loglevel no mergingObject"`
+                    );
+                    done();
+                });
+                const logger = createLogger({ type: "test", context: "app"});
+                logger.info("Loglevel no mergingObject");
+            });
+            it("should add the correct loglevel string if mergingObject is passed", (done) => {
+                spyOn(process.stdout,"write").and.callFake(log => {
+                    expect(log).toContain(
+                        `"type":"test","context":"app","a":"b","loglevel":"WARN","message":"Loglevel with mergingObject"`
+                    );
+                    done();
+                });
+                const logger = createLogger({ type: "test", context: "app" });
+                logger.warn({ "a": "b" }, "Loglevel with mergingObject");
+            });
+            it("should add the correct loglevel string if we are logging an error message", (done) => {
+                spyOn(process.stdout,"write").and.callFake(log => {
+                    expect(log).toContain(
+                        `"type":"test","context":"app","error_stack":"Error: Loglevel with error`
+                    );
+                    expect(log).toContain(
+                        '"loglevel":"ERROR","message":"Loglevel with error"'
+                    );
+                    done();
+                });
+                const logger = createLogger({ type: "test", context: "app" });
+                logger.error(new Error("Loglevel with error"));
+            });
         });
     });
 
@@ -223,6 +208,17 @@ describe("Logger", () => {
                 });
                 const logger = getLogger();
                 logger.warn({"test":"not_stringify_warn","object":{"b":123},"string":"c","number":321,"array":["a",1,["subarray"]]}, "Don't stringify log");
+            });
+            it("should not add loglevel field", (done) => {
+                spyOn(process.stdout,"write").and.callFake(log => {
+                    expect(log).toContain(
+                        `"type":"test","context":"access","message":"No loglevel added"`
+                    );
+                    expect(log).not.toContain('"loglevel"');
+                    done();
+                });
+                const logger = createLogger({ type: "test", context: "access"});
+                logger.info("No loglevel added");
             });
         });
     });

--- a/index_spec.js
+++ b/index_spec.js
@@ -63,6 +63,18 @@ describe("Logger", () => {
             const logger = createLogger({ type: "test", context: "app"});
             logger.warn({"test":"stringify_functions","function": function () {return true}}, "Stringify functions");
         });
+
+        xit("should serialize Error stack", (done) => {
+            // spyOn(process.stdout,"write").and.callFake(log => {
+            //     expect(log).toContain('"message":"This is an error"');
+            //     expect(log).toContain('"error_stack":"Error: This is an error');
+            //     expect(log).not.toContain('"stack"');
+            //     done();
+            // });
+            const logger = createLogger({ type: "test", context: "app"}).child({pippo:"pluto"});
+            logger.error(new Error("This is an error"));
+            done();
+        });
     });
 
     describe("access", () => {
@@ -95,6 +107,16 @@ describe("Logger", () => {
             });
             const logger = createLogger({ type: "test", context: "access"});
             logger.warn({"test":"not_stringify_warn","object":{"b":123},"string":"c","number":321,"array":["a",1,["subarray"]]}, "Don't stringify log");
+        });
+        it("should serialize Error stack", (done) => {
+            spyOn(process.stdout,"write").and.callFake(log => {
+                expect(log).toContain('"message":"This is an error"');
+                expect(log).toContain('"error_stack":"Error: This is an error');
+                expect(log).not.toContain('"stack"');
+                done();
+            });
+            const logger = createLogger({ type: "test", context: "app"});
+            logger.error(new Error("This is an error"));
         });
     })
 });

--- a/jasmine-nodemon.json
+++ b/jasmine-nodemon.json
@@ -2,6 +2,7 @@
     "verbose": true,
     "watch": [
         "index.js",
+        "/utils/*",
         "*_spec.js"
     ],
     "ignore": [],

--- a/jasmine.json
+++ b/jasmine.json
@@ -1,7 +1,8 @@
 {
     "spec_dir": ".",
     "spec_files": [
-        "*_spec.js"
+        "*_spec.js",
+        "utils/*spec.js"
     ],
     "helpers": [],
     "stopSpecOnExpectationFailure": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@spreaker/logger",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -2292,6 +2292,11 @@
             "requires": {
                 "extend-shallow": "3.0.2"
             }
+        },
+        "stack-trace": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
         },
         "static-extend": {
             "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@spreaker/logger",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "description": "Pino-based wrapper with some extra capabilities.",
     "engines": {
         "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     },
     "homepage": "https://github.com/spreaker/pkg-node-logger#readme",
     "dependencies": {
-        "pino": "^5.13.1"
+        "pino": "^5.13.1",
+        "stack-trace": "^0.0.10"
     },
     "devDependencies": {
         "jasmine": "^3.1.0",

--- a/utils/levels.js
+++ b/utils/levels.js
@@ -1,0 +1,7 @@
+const getLevelAsString = (levels, level) => {
+    return levels && levels.labels[level] ? levels.labels[level].toUpperCase() : null;
+};
+
+module.exports = {
+    getLevelAsString
+};

--- a/utils/levels.js
+++ b/utils/levels.js
@@ -1,5 +1,14 @@
-const getLevelAsString = (levels, level) => {
-    return levels && levels.labels[level] ? levels.labels[level].toUpperCase() : null;
+const LEVELS = {
+    "10": "DEBUG",
+    "20": "DEBUG",
+    "30": "INFO",
+    "40": "WARN",
+    "50": "ERROR",
+    "60": "FATAL"
+};
+
+const getLevelAsString = (level) => {
+    return LEVELS[level] ? LEVELS[level] : null;
 };
 
 module.exports = {

--- a/utils/levels_spec.js
+++ b/utils/levels_spec.js
@@ -1,0 +1,27 @@
+const { getLevelAsString } = require("./levels");
+
+describe("getLevelAsString", () => {
+    it("should return the loglevel string that match the level", () => {
+        expect(getLevelAsString(10)).toBe("DEBUG");
+        expect(getLevelAsString(20)).toBe("DEBUG");
+        expect(getLevelAsString(30)).toBe("INFO");
+        expect(getLevelAsString(40)).toBe("WARN");
+        expect(getLevelAsString(50)).toBe("ERROR");
+        expect(getLevelAsString(60)).toBe("FATAL");
+    });
+    it("should return the loglevel string that match the level, also if level is a string", () => {
+        expect(getLevelAsString("10")).toBe("DEBUG");
+        expect(getLevelAsString("20")).toBe("DEBUG");
+        expect(getLevelAsString("30")).toBe("INFO");
+        expect(getLevelAsString("40")).toBe("WARN");
+        expect(getLevelAsString("50")).toBe("ERROR");
+        expect(getLevelAsString("60")).toBe("FATAL");
+    });
+    it("should return null if there is no match", () => {
+        expect(getLevelAsString()).toBe(null);
+        expect(getLevelAsString("0")).toBe(null);
+        expect(getLevelAsString(100)).toBe(null);
+        expect(getLevelAsString(null)).toBe(null);
+        expect(getLevelAsString(NaN)).toBe(null);
+    });
+});

--- a/utils/parseErrorStack.js
+++ b/utils/parseErrorStack.js
@@ -1,0 +1,24 @@
+const stackTrace = require("stack-trace");
+
+module.exports = (err) => {
+    try {
+        const parseTrace = stackTrace.parse(err)[0];
+        const obj = {
+            stackTrace: err.stack,
+            fileName: parseTrace.getFileName(),
+            lineNumber: parseTrace.getLineNumber(),
+            functionName: parseTrace.getFunctionName(),
+            columnNumber: parseTrace.getColumnNumber(),
+        };
+        return obj;
+    } catch (e) {
+        const obj = {
+            stackTrace: (err && err.stack) || null,
+            fileName: null,
+            lineNumber: null,
+            functionName: null,
+            columnNumber: null,
+        };
+        return obj;
+    }
+};

--- a/utils/parseErrorStack_spec.js
+++ b/utils/parseErrorStack_spec.js
@@ -1,0 +1,53 @@
+const parseErrorStack = require("./parseErrorStack");
+
+describe("Parse error stack trace", () => {
+    it("should parse a simple valid stack trace", () => {
+        const error = {
+            stack: "Error: pippo\n    at GetPippo (/workspace/pippo.js:1:1)",
+        };
+
+        const errorStackParsed = parseErrorStack(error);
+
+        expect(errorStackParsed).toEqual({
+            stackTrace: "Error: pippo\n    at GetPippo (/workspace/pippo.js:1:1)",
+            fileName: "/workspace/pippo.js",
+            lineNumber: 1,
+            functionName: "GetPippo",
+            columnNumber: 1,
+        });
+    });
+
+    it("should parse a complex valid stack trace", () => {
+        const error = {
+            stack:
+                "Error: pippo\n    at GetLogin (/workspace/app-dynamo/apps/admin/server/src/routes/Login.js:14:11)\n    at dispatch (/workspace/app-dynamo/node_modules/koa-router/node_modules/koa-compose/index.js:44:32)\n    at next (/workspace/app-dynamo/node_modules/koa-router/node_modules/koa-compose/index.js:45:18)\n    at module.exports (/workspace/app-dynamo/apps/admin/server/src/middlewares/CheckLoginAccessMiddleware.js:6:15)\n    at dispatch (/workspace/app-dynamo/node_modules/koa-router/node_modules/koa-compose/index.js:44:32)\n    at next (/workspace/app-dynamo/node_modules/koa-router/node_modules/koa-compose/index.js:45:18)\n    at /workspace/app-dynamo/node_modules/koa-generic-session/lib/session.js:264:15\n    at Generator.next (<anonymous>)\n    at step (/workspace/app-dynamo/node_modules/koa-generic-session/lib/session.js:3:191)\n    at /workspace/app-dynamo/node_modules/koa-generic-session/lib/session.js:3:361",
+        };
+
+        const errorStackParsed = parseErrorStack(error);
+
+        expect(errorStackParsed).toEqual({
+            stackTrace:
+                "Error: pippo\n    at GetLogin (/workspace/app-dynamo/apps/admin/server/src/routes/Login.js:14:11)\n    at dispatch (/workspace/app-dynamo/node_modules/koa-router/node_modules/koa-compose/index.js:44:32)\n    at next (/workspace/app-dynamo/node_modules/koa-router/node_modules/koa-compose/index.js:45:18)\n    at module.exports (/workspace/app-dynamo/apps/admin/server/src/middlewares/CheckLoginAccessMiddleware.js:6:15)\n    at dispatch (/workspace/app-dynamo/node_modules/koa-router/node_modules/koa-compose/index.js:44:32)\n    at next (/workspace/app-dynamo/node_modules/koa-router/node_modules/koa-compose/index.js:45:18)\n    at /workspace/app-dynamo/node_modules/koa-generic-session/lib/session.js:264:15\n    at Generator.next (<anonymous>)\n    at step (/workspace/app-dynamo/node_modules/koa-generic-session/lib/session.js:3:191)\n    at /workspace/app-dynamo/node_modules/koa-generic-session/lib/session.js:3:361",
+            fileName: "/workspace/app-dynamo/apps/admin/server/src/routes/Login.js",
+            lineNumber: 14,
+            functionName: "GetLogin",
+            columnNumber: 11,
+        });
+    });
+
+    it("should not brake in case of invalid stack trace", () => {
+        const error = {
+            stack: "Error: pippo   at GetPippo (/workspace/pippo.js:1:1)",
+        };
+
+        const errorStackParsed = parseErrorStack(error);
+
+        expect(errorStackParsed).toEqual({
+            stackTrace: "Error: pippo   at GetPippo (/workspace/pippo.js:1:1)",
+            fileName: null,
+            lineNumber: null,
+            functionName: null,
+            columnNumber: null,
+        });
+    });
+});

--- a/utils/serializers.js
+++ b/utils/serializers.js
@@ -69,11 +69,11 @@ const serializeError = (arguments) => {
 /**
  * Add loglevel field to have a string version of the log level
  */
-const serializeLogLevel = (levels, arguments) => {
+const serializeLogLevel = (arguments) => {
     if (!arguments[0]) {
         arguments[0] = {}
     }
-    arguments[0].loglevel = getLevelAsString(levels, arguments[2]);
+    arguments[0].loglevel = getLevelAsString(arguments[2]);
 }
 
 module.exports = {

--- a/utils/serializers.js
+++ b/utils/serializers.js
@@ -1,0 +1,67 @@
+/**
+ * List of default field that should not be transformed by the serializer
+*/
+const whitelist = ["time", "pid"];
+
+const getCustomSerializers = (type) => {
+    return {
+        "app": ( obj ) => {
+            Object.keys(obj).forEach(key => {
+                switch(key) {
+                    // Avoid that someone overwrites the type field
+                    // because we use it to detect the application
+                    case "type":
+                        obj.type = type;
+                        break;
+                    // Serializer to add 'error_stack' field
+                    case "stack":
+                        obj["error_stack"] = obj[key];
+                        break;
+                    default:
+                        serializeToString(key, obj);
+                }
+            });
+            return obj;
+        },
+        "access": ( obj ) => {
+            Object.keys(obj).forEach(key => {
+                switch(key) {
+                    // Avoid that someone overwrites the type field
+                    // because we use it to detect the application
+                    case "type":
+                        obj.type = type;
+                        break;
+                    // Serializer to add 'error_stack' field
+                    case "stack":
+                        obj["error_stack"] = obj[key];
+                }
+            });
+            return obj;
+        }
+    }
+};
+
+
+/**
+ * Serializer to transform values into string
+*/
+const serializeToString = (key, obj) => {
+    if (whitelist.indexOf(key) === -1) {
+        // Try to stringify objects/array or transform other types in string
+        try {
+            if (typeof obj[key] === "object" || obj[key] instanceof Array) {
+                obj[key] = JSON.stringify(obj[key]);
+            } else {
+                obj[key] = String(obj[key]);
+            }
+        } 
+        // in case of errors just return the current value
+        catch(err) {
+            obj[key] = obj[key];
+        }
+    }
+};
+
+module.exports = {
+    getCustomSerializers
+};


### PR DESCRIPTION
In this PR we want to add 2 functions to our logger:
- errors serialization
- add loglevel field to each logs

To be able to develop them I've proxied the `Pino logger` and I've intercepted the `write` method; in this way I had the possibility to insert these customizations before call the original method.
I've added some comments and updated the `README` to explain the changes better.