### PR TITLE
Add prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,10 @@
 Pino-based Logger that we use in all of Spreaker's nodeJS projects. 
 It's possible to create 2 different instances of the logger:
 
-- `Application Logger`: this is an instance of `Pino Logger`, initialized with `Spreaker's base options`, with a custom serializer that take care of stringify objects and array and transforming other types into string before log.
+- `Application Logger`: this is an instance of `Pino Logger`, initialized with `Spreaker's base options`, with a custom serializer that take care of stringify objects and array and transforming other types into string before log. All the fields are decorated with a prefix `v2_` to make them recognizables. The `Application Logger` add also a `v2_loglevel` field to each log to have a string version of the log level.
 - `Access Logger`: this is an instance of `Pino Logger`, initialized with `Spreaker's base options`.
 
-Both the loggers provide 2 common functions:
-- Add `loglevel` field to each log to have a string version of the log level
+Both the loggers provide a common functions:
 - Errors serializer that take care of set the correct error fields in the logs
 
 
@@ -50,7 +49,7 @@ logger.info(
 ```
 will produce a log like:
 ```
-{"level":30,"time":1566908680683,"type":"test","context":"app","object":"{\"b\":123}","string":"c","number":"321","array":"[\"a\",1,[\"subarray\"]]","message":"Stringify log","loglevel":"INFO","v":1}
+{"level":30,"time":1566908680683,"v2_type":"test","v2_context":"app","v2_object":"{\"b\":123}","v2_string":"c","v2_number":"321","v2_array":"[\"a\",1,[\"subarray\"]]","v2_message":"Stringify log","v2_loglevel":"INFO","v":1}
 ```
 
 ### Access logger
@@ -69,7 +68,7 @@ logger.info(
 ```
 will produce a log like:
 ```
-{"level":30,"time":1566908953080,"type":"test","context":"access","object":{"b":123},"string":"c","number":321,"array":["a",1,["subarray"]],"message":"Don't stringify log","loglevel":"INFO","v":1}
+{"level":30,"time":1566908953080,"type":"test","context":"access","object":{"b":123},"string":"c","number":321,"array":["a",1,["subarray"]],"message":"Don't stringify log","v":1}
 ```
 
 ## Errors serializer

--- a/README.md
+++ b/README.md
@@ -20,15 +20,22 @@ Both the loggers provide a common functions:
 ```js
 const { createLogger } = require("@spreaker/logger");
 
-// Create logger passing the initial properties and the logLevel. 
+// Create logger passing the initial properties and the options: minLoglevel and destination. 
 // Mandatory properties are: 
 // - `type` (name of application is using the logger)
 // - `context` (type of logger to create: "app" or "access")
-// Minimum level of log enabled; if not passed is "info".
-const logger = createLogger({ type: "test", context: "app"}, "info");
+// Options object is not mandatory:
+// - `minLoglevel` (Minimum level of log enabled; if not passed is "info")
+// - `destination` (Path of logs destination; useful for tests. If not passed STDOUT is the default one)
+const logger = createLogger({ type: "test", context: "app"}, { minLoglevel: "info" });
 
 // Use the logger as a simple `Pino` child instance.
 logger.info({a: "b", c: 123}, "Message to log");
+
+const loggerWithDestination = createLogger({ type: "test", context: "app"}, { destination: "/path/to/file" });
+
+// Logs will be saved into this file: /path/to/file
+loggerWithDestination.info({a: "b", c: 123}, "Message to log");
 ```
 
 ## Logger types

--- a/index.js
+++ b/index.js
@@ -36,7 +36,8 @@ const createLogger = (props, minLoglevel) => {
      * the ones passed in the initialization that are not
      * available in the pino.write
      */ 
-    if (props.context === "app") {
+    const context = props.context.valueOf(); // We clone the value of the props and not use it directly to avoid that this variable has impacted by the serializations
+    if (context === "app") {
         options.serializers = serializers;
     }
 
@@ -46,7 +47,7 @@ const createLogger = (props, minLoglevel) => {
             if(prop.toString() === "Symbol(pino.write)"){
                 return function () {
                     serializeError(arguments);
-                    if (props.context === "app") {
+                    if (context === "app") {
                         serializeLogLevel(arguments);
                     }
                     target[prop].apply(this, arguments);

--- a/index.js
+++ b/index.js
@@ -19,7 +19,9 @@ serializers[Symbol.for('pino.*')] = (obj) =>{
 * @param {Object} props Logger initial configuration
 * @param {string} props.type Name of application is using the Logger
 * @param {string} props.context Which Logger user want to create: "app" or "access"
-* @param {string} minLoglevel minimum level of log enabled: "trace", "debug", "info", "warn", "error", and "fatal"
+* @param {Object} options Logger options
+* @param {string} options.minLoglevel minimum level of log enabled: "trace", "debug", "info", "warn", "error", and "fatal"
+* @param {string} options.destination path of logs destination. If not passed STDOUT is the default one
 */
 const createLogger = (props, { minLoglevel, destination } = {}) => {
     const options = {

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ serializers[Symbol.for('pino.*')] = (obj) =>{
 * @param {string} props.context Which Logger user want to create: "app" or "access"
 * @param {string} minLoglevel minimum level of log enabled: "trace", "debug", "info", "warn", "error", and "fatal"
 */
-const createLogger = (props, minLoglevel) => {
+const createLogger = (props, { minLoglevel, destination } = {}) => {
     const options = {
         messageKey: "message",
         base: null,
@@ -41,7 +41,9 @@ const createLogger = (props, minLoglevel) => {
         options.serializers = serializers;
     }
 
-    const customPino = new Proxy(pino(options), {
+    const destOut = destination ? pino.destination(destination) : null;
+
+    const customPino = new Proxy(pino(options, destOut), {
         get: function (target, prop) {
             // Proxy the logger and intercept the 'write' fnc to be able to customize the logs
             if(prop.toString() === "Symbol(pino.write)"){

--- a/index_spec.js
+++ b/index_spec.js
@@ -2,81 +2,29 @@ const { createLogger } = require("./index");
 
 describe("Logger", () => {
 
-    ["app","access"].forEach(context => {
-        describe(`serialize Errors for ${context} logger`, () => {
-            it("should add common error fields and error_message if log message is present", (done) => {
-                spyOn(process.stdout,"write").and.callFake(log => {
-                    expect(log).toContain('"message":"Error with log message"');
-                    expect(log).toContain('"error_stack":"Error: This is an error');
-                    expect(log).toContain('"error_message":"This is an error');
-                    expect(log).toContain('"error_file"');
-                    expect(log).toContain('"error_line"');
-                    expect(log).not.toContain('"stack"');
-                    done();
-                });
-                const logger = createLogger({ type: "test", context });
-                logger.error(new Error("This is an error"), "Error with log message");
-            });
-
-            it("should add common error fields and use Error.message as message if log message is not present", (done) => {
-                spyOn(process.stdout,"write").and.callFake(log => {
-                    expect(log).toContain('"message":"Error without log message"');
-                    expect(log).toContain('"error_stack":"Error: Error without log message');
-                    expect(log).toContain('"error_file"');
-                    expect(log).toContain('"error_line"');
-                    expect(log).not.toContain('"error_message"');
-                    expect(log).not.toContain('"stack"');
-                    done();
-                });
-                const logger = createLogger({ type: "test", context });
-                logger.error(new Error("Error without log message"));
-            });
-
-            it("should add common error fields and use Error.message as message if log message is the Error", (done) => {
-                spyOn(process.stdout,"write").and.callFake(log => {
-                    expect(log).toContain('"a":"b"');
-                    expect(log).toContain('"message":"Error as log message"');
-                    expect(log).toContain('"error_stack":"Error: Error as log message');
-                    expect(log).toContain('"error_file"');
-                    expect(log).toContain('"error_line"');
-                    expect(log).not.toContain('"error_message"');
-                    expect(log).not.toContain('"stack"');
-                    done();
-                });
-                const logger = createLogger({ type: "test", context });
-                logger.error({ "a": "b" }, new Error("Error as log message"));
-            });
-
-            it("should works also for child logger", (done) => {
-                spyOn(process.stdout,"write").and.callFake(log => {
-                    expect(log).toContain('"message":"Error of child logger"');
-                    expect(log).toContain('"error_stack":"Error: This is an error');
-                    expect(log).toContain('"error_file"');
-                    expect(log).toContain('"error_line"');
-                    expect(log).toContain('"error_message":"This is an error');
-                    expect(log).not.toContain('"stack"');
-                    done();
-                });
-                const logger = createLogger({ type: "test", context }).child({});
-                logger.error(new Error("This is an error"), "Error of child logger");
-            });
-        });
-    });
-
     ["parent", "child"].forEach(type => {
         describe(`${type} application logger`, () => {
-            const getLogger = () => {
-                let logger = createLogger({ type: "test", context: "app"});
+            const getLogger = (minLogValue) => {
+                let logger = createLogger({ type: "test", context: "app"}, minLogValue);
                 if (type === "child") {
                     logger = logger.child({});
                 }
                 return logger;
             }
-
+            it("should add 'v2_' prefix to all the fields, except for the whitelisted ones", (done) => {
+                spyOn(process.stdout,"write").and.callFake(log => {
+                    expect(log).toContain(
+                        '"v2_type":"test","v2_context":"app","time":123,"pid":"321","v2_loglevel":"INFO","v2_message":"Add prefix"'
+                    );
+                    done();
+                });
+                const logger = getLogger();
+                logger.info({"time":123,"pid":"321"}, "Add prefix");
+            });
             it("should log the initial properties passed", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain(
-                        '"type":"test","context":"app","test":"initial_properties"'
+                        '"v2_type":"test","v2_context":"app","v2_test":"initial_properties"'
                     );
                     done();
                 });
@@ -86,17 +34,17 @@ describe("Logger", () => {
             it("should not transform fields in the whitelist", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain(
-                        '"test":"whitelist","time":123,"pid":321'
+                        '"time":123,"pid":321'
                     );
                     done();
                 });
                 const logger = getLogger();
-                logger.info({"test":"whitelist","time":123,"pid":321}, "Don't transform whitelist");
+                logger.info({"time":123,"pid":321}, "Don't transform whitelist");
             });
             it("should stringify objects or array and transform other types into string before log INFO", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain(
-                        '"test":"stringify_info","object":"{\\\"b\\\":123}","string":"c","number":"321","array":"[\\\"a\\\",1,[\\\"subarray\\\"]]"'
+                        '"v2_test":"stringify_info","v2_object":"{\\\"b\\\":123}","v2_string":"c","v2_number":"321","v2_array":"[\\\"a\\\",1,[\\\"subarray\\\"]]"'
                     );
                     done();
                 });
@@ -106,7 +54,7 @@ describe("Logger", () => {
             it("should stringify objects or array and transform other types into string before log WARN", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain(
-                        '"test":"stringify_warn","object":"{\\\"b\\\":123}","string":"c","number":"321","array":"[\\\"a\\\",1,[\\\"subarray\\\"]]"'
+                        '"v2_test":"stringify_warn","v2_object":"{\\\"b\\\":123}","v2_string":"c","v2_number":"321","v2_array":"[\\\"a\\\",1,[\\\"subarray\\\"]]"'
                     );
                     done();
                 });
@@ -116,7 +64,7 @@ describe("Logger", () => {
             it("should transform null or boolean fields into string", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain(
-                        '"test":"stringify_null","a":"null","b":"true"'
+                        '"v2_test":"stringify_null","v2_a":"null","v2_b":"true"'
                     );
                     done();
                 });
@@ -126,7 +74,7 @@ describe("Logger", () => {
             it("should stringify functions", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain(
-                        '"test":"stringify_functions","function":"function () {return true}"'
+                        '"v2_test":"stringify_functions","v2_function":"function () {return true}"'
                     );
                     done();
                 });
@@ -136,45 +84,81 @@ describe("Logger", () => {
             it("should add the correct loglevel string if no mergingObject is passed", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain(
-                        '"type":"test","context":"app","loglevel":"INFO","message":"Loglevel no mergingObject"'
+                        '"v2_type":"test","v2_context":"app","v2_loglevel":"INFO","v2_message":"Loglevel no mergingObject"'
                     );
                     done();
                 });
-                const logger = createLogger({ type: "test", context: "app"});
+                const logger = getLogger();
                 logger.info("Loglevel no mergingObject");
             });
             it("should add the correct loglevel string if mergingObject is passed", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain(
-                        '"type":"test","context":"app","a":"b","loglevel":"WARN","message":"Loglevel with mergingObject"'
+                        '"v2_type":"test","v2_context":"app","v2_a":"b","v2_loglevel":"WARN","v2_message":"Loglevel with mergingObject"'
                     );
                     done();
                 });
-                const logger = createLogger({ type: "test", context: "app" });
+                const logger = getLogger();
                 logger.warn({ "a": "b" }, "Loglevel with mergingObject");
-            });
-            it("should add the correct loglevel string if we are logging an error message", (done) => {
-                spyOn(process.stdout,"write").and.callFake(log => {
-                    expect(log).toContain(
-                        '"type":"test","context":"app","error_stack":"Error: Loglevel with error'
-                    );
-                    expect(log).toContain(
-                        '"loglevel":"ERROR","message":"Loglevel with error"'
-                    );
-                    done();
-                });
-                const logger = createLogger({ type: "test", context: "app" });
-                logger.error(new Error("Loglevel with error"));
             });
             it("should add loglevel = DEBUG for trace logs", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain(
-                        '"type":"test","context":"app","loglevel":"DEBUG","message":"Replace trace with debug"'
+                        '"v2_type":"test","v2_context":"app","v2_loglevel":"DEBUG","v2_message":"Replace trace with debug"'
                     );
                     done();
                 });
-                const logger = createLogger({ type: "test", context: "app" }, "trace");
+                const logger = getLogger("trace");
                 logger.trace("Replace trace with debug");
+            });
+
+            describe(`serialize Errors`, () => {
+                it("should add common error fields and error_message if log message is present", (done) => {
+                    spyOn(process.stdout,"write").and.callFake(log => {
+                        expect(log).toContain('"v2_message":"Error with log message"');
+                        expect(log).toContain('"v2_error_stack":"Error: This is an error');
+                        expect(log).toContain('"v2_error_message":"This is an error');
+                        expect(log).toContain('"v2_error_file"');
+                        expect(log).toContain('"v2_error_line"');
+                        expect(log).not.toContain('"v2_stack"');
+                        expect(log).not.toContain('"stack"');
+                        done();
+                    });
+                    const logger = getLogger();
+                    logger.error(new Error("This is an error"), "Error with log message");
+                });
+    
+                it("should add common error fields and use Error.message as message if log message is not present", (done) => {
+                    spyOn(process.stdout,"write").and.callFake(log => {
+                        expect(log).toContain('"v2_message":"Error without log message"');
+                        expect(log).toContain('"v2_error_stack":"Error: Error without log message');
+                        expect(log).toContain('"v2_error_file"');
+                        expect(log).toContain('"v2_error_line"');
+                        expect(log).not.toContain('"error_message"');
+                        expect(log).not.toContain('"v2_stack"');
+                        expect(log).not.toContain('"stack"');
+                        done();
+                    });
+                    const logger = getLogger();
+                    logger.error(new Error("Error without log message"));
+                });
+    
+                it("should add common error fields and use Error.message as message if log message is the Error", (done) => {
+                    spyOn(process.stdout,"write").and.callFake(log => {
+                        expect(log).toContain('"v2_a":"b"');
+                        expect(log).toContain('"v2_message":"Error as log message"');
+                        expect(log).toContain('"v2_error_stack":"Error: Error as log message');
+                        expect(log).toContain('"v2_error_file"');
+                        expect(log).toContain('"v2_error_line"');
+                        expect(log).not.toContain('"v2_error_message"');
+                        expect(log).not.toContain('"v2_stack"');
+                        expect(log).not.toContain('"stack"');
+                        done();
+                    });
+                    const logger = getLogger();
+                    logger.error({ "a": "b" }, new Error("Error as log message"));
+                    done();
+                });
             });
         });
     });
@@ -227,8 +211,54 @@ describe("Logger", () => {
                     expect(log).not.toContain('"loglevel"');
                     done();
                 });
-                const logger = createLogger({ type: "test", context: "access"});
+                const logger = getLogger();
                 logger.info("No loglevel added");
+            });
+
+            describe(`serialize Errors`, () => {
+                it("should add common error fields and error_message if log message is present", (done) => {
+                    spyOn(process.stdout,"write").and.callFake(log => {
+                        expect(log).toContain('"message":"Error with log message"');
+                        expect(log).toContain('"error_stack":"Error: This is an error');
+                        expect(log).toContain('"error_message":"This is an error');
+                        expect(log).toContain('"error_file"');
+                        expect(log).toContain('"error_line"');
+                        expect(log).not.toContain('"stack"');
+                        done();
+                    });
+                    const logger = getLogger();
+                    logger.error(new Error("This is an error"), "Error with log message");
+                });
+    
+                it("should add common error fields and use Error.message as message if log message is not present", (done) => {
+                    spyOn(process.stdout,"write").and.callFake(log => {
+                        expect(log).toContain('"message":"Error without log message"');
+                        expect(log).toContain('"error_stack":"Error: Error without log message');
+                        expect(log).toContain('"error_file"');
+                        expect(log).toContain('"error_line"');
+                        expect(log).not.toContain('"error_message"');
+                        expect(log).not.toContain('"stack"');
+                        done();
+                    });
+                    const logger = getLogger();
+                    logger.error(new Error("Error without log message"));
+                });
+    
+                it("should add common error fields and use Error.message as message if log message is the Error", (done) => {
+                    spyOn(process.stdout,"write").and.callFake(log => {
+                        expect(log).toContain('"a":"b"');
+                        expect(log).toContain('"message":"Error as log message"');
+                        expect(log).toContain('"error_stack":"Error: Error as log message');
+                        expect(log).toContain('"error_file"');
+                        expect(log).toContain('"error_line"');
+                        expect(log).not.toContain('"error_message"');
+                        expect(log).not.toContain('"stack"');
+                        done();
+                    });
+                    const logger = getLogger();
+                    logger.error({ "a": "b" }, new Error("Error as log message"));
+                    done();
+                });
             });
         });
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@spreaker/logger",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Pino-based wrapper with some extra capabilities.",
     "engines": {
         "node": ">=8"

--- a/utils/serializers.js
+++ b/utils/serializers.js
@@ -11,13 +11,18 @@ const whitelist = ["time", "pid"];
 */
 const serializeToString = (key, obj) => {
     if (whitelist.indexOf(key) === -1) {
+        // we create a new key with "v2_" prefix to recognize field serialized
+        // and avoid collision with old keys not serialized
+        const newKey = `v2_${key}`;
         // Try to stringify objects/array or transform other types in string
         try {
             if (typeof obj[key] === "object" || obj[key] instanceof Array) {
-                obj[key] = JSON.stringify(obj[key]);
+                obj[newKey] = JSON.stringify(obj[key]);
             } else {
-                obj[key] = String(obj[key]);
+                obj[newKey] = String(obj[key]);
             }
+            // if the process goes well we delete the not serialized key
+            delete obj[key];
         } 
         // in case of errors just return the current value
         catch(err) {


### PR DESCRIPTION
- Added `v2_` prefix to all fields of an `Application log`, a part from the whitelisted ones.
- Added `destination` option to allow save logs in a file (useful for testing when spy the `process.stdout` it's too complicated)
- Fixed tests
- Updated and fixed README