### PR TITLE
Added code field in Error serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ will produce a log like:
 ```js
 {
     error_stack: "error stack trace",
+    error_code: "error code property",
     error_file: "path of the file",
     error_line: "number of the line"
 }

--- a/index_spec.js
+++ b/index_spec.js
@@ -138,6 +138,7 @@ describe("Logger", () => {
                     spyOn(process.stdout,"write").and.callFake(log => {
                         expect(log).toContain('"v2_message":"Error with log message"');
                         expect(log).toContain('"v2_error_stack":"Error: This is an error');
+                        expect(log).toContain('"v2_error_code":"ERR_CODE"');
                         expect(log).toContain('"v2_error_message":"This is an error');
                         expect(log).toContain('"v2_error_file"');
                         expect(log).toContain('"v2_error_line"');
@@ -146,13 +147,16 @@ describe("Logger", () => {
                         done();
                     });
                     const logger = getLogger();
-                    logger.error(new Error("This is an error"), "Error with log message");
+                    const error = new Error("This is an error");
+                    error.code = "ERR_CODE";
+                    logger.error(error, "Error with log message");
                 });
     
                 it("should add common error fields and use Error.message as message if log message is not present", (done) => {
                     spyOn(process.stdout,"write").and.callFake(log => {
                         expect(log).toContain('"v2_message":"Error without log message"');
                         expect(log).toContain('"v2_error_stack":"Error: Error without log message');
+                        expect(log).toContain('"v2_error_code":"ERR_CODE"');
                         expect(log).toContain('"v2_error_file"');
                         expect(log).toContain('"v2_error_line"');
                         expect(log).not.toContain('"error_message"');
@@ -161,7 +165,9 @@ describe("Logger", () => {
                         done();
                     });
                     const logger = getLogger();
-                    logger.error(new Error("Error without log message"));
+                    const error = new Error("Error without log message");
+                    error.code = "ERR_CODE";
+                    logger.error(error);
                 });
     
                 it("should add common error fields and use Error.message as message if log message is the Error", (done) => {
@@ -169,6 +175,7 @@ describe("Logger", () => {
                         expect(log).toContain('"v2_a":"b"');
                         expect(log).toContain('"v2_message":"Error as log message"');
                         expect(log).toContain('"v2_error_stack":"Error: Error as log message');
+                        expect(log).toContain('"v2_error_code":"ERR_CODE"');
                         expect(log).toContain('"v2_error_file"');
                         expect(log).toContain('"v2_error_line"');
                         expect(log).not.toContain('"v2_error_message"');
@@ -177,8 +184,24 @@ describe("Logger", () => {
                         done();
                     });
                     const logger = getLogger();
-                    logger.error({ "a": "b" }, new Error("Error as log message"));
-                    done();
+                    const error = new Error("Error as log message");
+                    error.code = "ERR_CODE";
+                    logger.error({ "a": "b" }, error);
+                });
+                
+                it("should not add error code if not present in Error instance", (done) => {
+                    spyOn(process.stdout,"write").and.callFake(log => {
+                        expect(log).toContain('"v2_error_stack":"Error: Error without code');
+                        expect(log).toContain('"v2_error_file"');
+                        expect(log).toContain('"v2_error_line"');
+                        expect(log).not.toContain('"v2_error_message"');
+                        expect(log).not.toContain('"v2_error_code"');
+                        expect(log).not.toContain('"v2_stack"');
+                        expect(log).not.toContain('"stack"');
+                        done();
+                    });
+                    const logger = getLogger();
+                    logger.error(new Error("Error without code"));
                 });
             });
         });
@@ -241,6 +264,7 @@ describe("Logger", () => {
                     spyOn(process.stdout,"write").and.callFake(log => {
                         expect(log).toContain('"message":"Error with log message"');
                         expect(log).toContain('"error_stack":"Error: This is an error');
+                        expect(log).toContain('"error_code":"ERR_CODE"');
                         expect(log).toContain('"error_message":"This is an error');
                         expect(log).toContain('"error_file"');
                         expect(log).toContain('"error_line"');
@@ -248,13 +272,16 @@ describe("Logger", () => {
                         done();
                     });
                     const logger = getLogger();
-                    logger.error(new Error("This is an error"), "Error with log message");
+                    const error = new Error("This is an error");
+                    error.code = "ERR_CODE";
+                    logger.error(error, "Error with log message");
                 });
     
                 it("should add common error fields and use Error.message as message if log message is not present", (done) => {
                     spyOn(process.stdout,"write").and.callFake(log => {
                         expect(log).toContain('"message":"Error without log message"');
                         expect(log).toContain('"error_stack":"Error: Error without log message');
+                        expect(log).toContain('"error_code":"ERR_CODE"');
                         expect(log).toContain('"error_file"');
                         expect(log).toContain('"error_line"');
                         expect(log).not.toContain('"error_message"');
@@ -262,7 +289,9 @@ describe("Logger", () => {
                         done();
                     });
                     const logger = getLogger();
-                    logger.error(new Error("Error without log message"));
+                    const error = new Error("Error without log message");
+                    error.code = "ERR_CODE";
+                    logger.error(error);
                 });
     
                 it("should add common error fields and use Error.message as message if log message is the Error", (done) => {
@@ -270,6 +299,7 @@ describe("Logger", () => {
                         expect(log).toContain('"a":"b"');
                         expect(log).toContain('"message":"Error as log message"');
                         expect(log).toContain('"error_stack":"Error: Error as log message');
+                        expect(log).toContain('"error_code":"ERR_CODE"');
                         expect(log).toContain('"error_file"');
                         expect(log).toContain('"error_line"');
                         expect(log).not.toContain('"error_message"');
@@ -277,8 +307,24 @@ describe("Logger", () => {
                         done();
                     });
                     const logger = getLogger();
-                    logger.error({ "a": "b" }, new Error("Error as log message"));
+                    const error = new Error("Error as log message");
+                    error.code = "ERR_CODE";
+                    logger.error({ "a": "b" }, error);
                     done();
+                });
+
+                it("should not add error code if not present in Error instance", (done) => {
+                    spyOn(process.stdout,"write").and.callFake(log => {
+                        expect(log).toContain('"error_stack":"Error: Error without code');
+                        expect(log).toContain('"error_file"');
+                        expect(log).toContain('"error_line"');
+                        expect(log).not.toContain('"error_message"');
+                        expect(log).not.toContain('"error_code"');
+                        expect(log).not.toContain('"stack"');
+                        done();
+                    });
+                    const logger = getLogger();
+                    logger.error(new Error("Error without code"));
                 });
             });
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@spreaker/logger",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "description": "Pino-based wrapper with some extra capabilities.",
     "engines": {
         "node": ">=8"

--- a/utils/parseErrorStack.js
+++ b/utils/parseErrorStack.js
@@ -5,6 +5,7 @@ module.exports = (err) => {
         const parseTrace = stackTrace.parse(err)[0];
         const obj = {
             stackTrace: err.stack,
+            code: err.code || null,
             fileName: parseTrace.getFileName(),
             lineNumber: parseTrace.getLineNumber(),
             functionName: parseTrace.getFunctionName(),
@@ -14,6 +15,7 @@ module.exports = (err) => {
     } catch (e) {
         const obj = {
             stackTrace: (err && err.stack) || null,
+            code: (err && err.code) || null,
             fileName: null,
             lineNumber: null,
             functionName: null,

--- a/utils/parseErrorStack_spec.js
+++ b/utils/parseErrorStack_spec.js
@@ -10,6 +10,7 @@ describe("Parse error stack trace", () => {
 
         expect(errorStackParsed).toEqual({
             stackTrace: "Error: pippo\n    at GetPippo (/workspace/pippo.js:1:1)",
+            code: null,
             fileName: "/workspace/pippo.js",
             lineNumber: 1,
             functionName: "GetPippo",
@@ -28,6 +29,7 @@ describe("Parse error stack trace", () => {
         expect(errorStackParsed).toEqual({
             stackTrace:
                 "Error: pippo\n    at GetLogin (/workspace/app-dynamo/apps/admin/server/src/routes/Login.js:14:11)\n    at dispatch (/workspace/app-dynamo/node_modules/koa-router/node_modules/koa-compose/index.js:44:32)\n    at next (/workspace/app-dynamo/node_modules/koa-router/node_modules/koa-compose/index.js:45:18)\n    at module.exports (/workspace/app-dynamo/apps/admin/server/src/middlewares/CheckLoginAccessMiddleware.js:6:15)\n    at dispatch (/workspace/app-dynamo/node_modules/koa-router/node_modules/koa-compose/index.js:44:32)\n    at next (/workspace/app-dynamo/node_modules/koa-router/node_modules/koa-compose/index.js:45:18)\n    at /workspace/app-dynamo/node_modules/koa-generic-session/lib/session.js:264:15\n    at Generator.next (<anonymous>)\n    at step (/workspace/app-dynamo/node_modules/koa-generic-session/lib/session.js:3:191)\n    at /workspace/app-dynamo/node_modules/koa-generic-session/lib/session.js:3:361",
+            code: null,
             fileName: "/workspace/app-dynamo/apps/admin/server/src/routes/Login.js",
             lineNumber: 14,
             functionName: "GetLogin",
@@ -44,6 +46,24 @@ describe("Parse error stack trace", () => {
 
         expect(errorStackParsed).toEqual({
             stackTrace: "Error: pippo   at GetPippo (/workspace/pippo.js:1:1)",
+            code: null,
+            fileName: null,
+            lineNumber: null,
+            functionName: null,
+            columnNumber: null,
+        });
+    });
+
+    it("should add code field if error code is present", () => {
+        const error = {
+            code: "ERR_ON_GET_PIPPO"
+        };
+
+        const errorStackParsed = parseErrorStack(error);
+
+        expect(errorStackParsed).toEqual({
+            stackTrace: null,
+            code: "ERR_ON_GET_PIPPO",
             fileName: null,
             lineNumber: null,
             functionName: null,

--- a/utils/serializers.js
+++ b/utils/serializers.js
@@ -32,11 +32,18 @@ const serializeToString = (key, obj) => {
 };
 
 const getErrorCommonFields = (obj) => {
-    return {
+    const error = {
         error_stack: obj.stackTrace,
         error_file: obj.fileName,
         error_line: obj.lineNumber
     }
+    // we don't return code field if not presents 
+    // to avoid printing a "null" string 
+    // caused by the serializeToString process
+    if (obj.code) {
+        error.error_code = obj.code;
+    }
+    return error;
 };
 
 /**


### PR DESCRIPTION
Since `nodeJs` use a `code` field as standard field to describe codification of an error, we decided to handle it and log it if presents, to improve error logging.