### PR TITLE
Added type, context, loglevel and message fields in the whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Pino-based Logger that we use in all of Spreaker's nodeJS projects. 
 It's possible to create 2 different instances of the logger:
 
-- `Application Logger`: this is an instance of `Pino Logger`, initialized with `Spreaker's base options`, with a custom serializer that take care of stringify objects and array and transforming other types into string before log. All the fields are decorated with a prefix `v2_` to make them recognizables. The `Application Logger` add also a `v2_loglevel` field to each log to have a string version of the log level.
+- `Application Logger`: this is an instance of `Pino Logger`, initialized with `Spreaker's base options`, with a custom serializer that take care of stringify objects and array and transforming other types into string before log. All the fields are decorated with a prefix `v2_` to make them recognizables. The `Application Logger` add also a `loglevel` field to each log to have a string version of the log level.
 - `Access Logger`: this is an instance of `Pino Logger`, initialized with `Spreaker's base options`.
 
 Both the loggers provide a common functions:
@@ -59,14 +59,14 @@ will produce a log like:
 { 
    "level":30,
    "time":1566908680683,
-   "v2_type":"test",
-   "v2_context":"app",
+   "type":"test",
+   "context":"app",
+   "message":"Stringify log",
+   "loglevel":"INFO",
    "v2_object":"{\"b\":123}",
    "v2_string":"c",
    "v2_number":"321",
    "v2_array":"[\"a\",1,[\"subarray\"]]",
-   "v2_message":"Stringify log",
-   "v2_loglevel":"INFO",
    "v":1
 }
 ```
@@ -112,7 +112,7 @@ will produce a log like:
 ## Errors serializer
 When you pass an error to the logger the possible scenarios are:
 
-- the Error is passed as `mergingObject` (first param) and the log has already a `message` (second param). In this case the logger add field `"error_message": Error.message` and [common error fields](#common-error-fields) to the `mergingObject` and the log message is printed in the `message` field
+- the Error is passed as `mergingObject` (first param) and the log has already a `message` (second param). In this case the logger add field `"v2_error_message": Error.message` and [common error fields](#common-error-fields) to the `mergingObject` and the log message is printed in the `message` field
 ```js
 logger.error(new Error("This is an error"), "Error with log message");
 ```
@@ -123,12 +123,12 @@ will produce a log like:
    "time":1567688722065,
    "type":"test",
    "context":"app",
-   "error_message":"This is an error",
-   "error_stack":"Error: This is an error...",
-   "error_file":"...",
-   "error_line":"...",
    "loglevel":"ERROR",
    "message":"Error with log message",
+   "v2_error_message":"This is an error",
+   "v2_error_stack":"Error: This is an error...",
+   "v2_error_file":"...",
+   "v2_error_line":"...",
    "v":1
 }
 ```
@@ -144,11 +144,11 @@ will produce a log like:
    "time":1567688853208,
    "type":"test",
    "context":"app",
-   "error_stack":"Error: Error without log message...",
-   "error_file":"...",
-   "error_line":"...",
    "loglevel":"ERROR",
    "message":"Error without log message",
+   "v2_error_stack":"Error: Error without log message...",
+   "v2_error_file":"...",
+   "v2_error_line":"...",
    "v":1
 }
 ```
@@ -165,17 +165,27 @@ will produce a log like:
    "time":1567689070052,
    "type":"test",
    "context":"app",
-   "a":"b",
-   "error_stack":"Error: Error as log message...",
-   "error_file":"...",
-   "error_line":"...",
    "loglevel":"ERROR",
    "message":"Error as log message",
+   "v2_a":"b",
+   "v2_error_stack":"Error: Error as log message...",
+   "v2_error_file":"...",
+   "v2_error_line":"...",
    "v":1
 }
 ```
 
 ### Common error fields
+In application logs
+```js
+{
+    v2_error_stack: "error stack trace",
+    v2_error_code: "error code property",
+    v2_error_file: "path of the file",
+    v2_error_line: "number of the line"
+}
+```
+or in access logs
 ```js
 {
     error_stack: "error stack trace",

--- a/index_spec.js
+++ b/index_spec.js
@@ -14,8 +14,8 @@ describe("Logger", () => {
             it("should use destination passed as logs output", () => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     const logs = fs.readFileSync(path.join(__dirname, "./logs")).toString();
-                    expect(logs).toContain(`"v2_type":"test","v2_context":"${context}"`);
-                    expect(logs).toContain('"v2_message":"Test destination"');
+                    expect(logs).toContain(`"type":"test","context":"${context}"`);
+                    expect(logs).toContain('"message":"Test destination"');
                 });
                 const logger = createLogger({ type: "test", context }, { destination: "./logs" });
                 logger.info("Test destination");
@@ -35,17 +35,17 @@ describe("Logger", () => {
             it("should add 'v2_' prefix to all the fields, except for the whitelisted ones", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain(
-                        '"v2_type":"test","v2_context":"app","time":123,"pid":"321","v2_loglevel":"INFO","v2_message":"Add prefix"'
+                        '"type":"test","context":"app","time":123,"pid":"321","loglevel":"INFO","message":"Add prefix","v2_toPrefix":"field to be prefixed"'
                     );
                     done();
                 });
                 const logger = getLogger();
-                logger.info({"time":123,"pid":"321"}, "Add prefix");
+                logger.info({"time":123,"pid":"321","toPrefix":"field to be prefixed"}, "Add prefix");
             });
             it("should log the initial properties passed", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain(
-                        '"v2_type":"test","v2_context":"app","v2_test":"initial_properties"'
+                        '"type":"test","context":"app","loglevel":"INFO","message":"Initial properties","v2_test":"initial_properties"'
                     );
                     done();
                 });
@@ -105,7 +105,7 @@ describe("Logger", () => {
             it("should add the correct loglevel string if no mergingObject is passed", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain(
-                        '"v2_type":"test","v2_context":"app","v2_loglevel":"INFO","v2_message":"Loglevel no mergingObject"'
+                        '"type":"test","context":"app","loglevel":"INFO","message":"Loglevel no mergingObject"'
                     );
                     done();
                 });
@@ -115,7 +115,7 @@ describe("Logger", () => {
             it("should add the correct loglevel string if mergingObject is passed", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain(
-                        '"v2_type":"test","v2_context":"app","v2_a":"b","v2_loglevel":"WARN","v2_message":"Loglevel with mergingObject"'
+                        '"type":"test","context":"app","loglevel":"WARN","message":"Loglevel with mergingObject","v2_a":"b"'
                     );
                     done();
                 });
@@ -125,7 +125,7 @@ describe("Logger", () => {
             it("should add loglevel = DEBUG for trace logs", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain(
-                        '"v2_type":"test","v2_context":"app","v2_loglevel":"DEBUG","v2_message":"Replace trace with debug"'
+                        '"type":"test","context":"app","loglevel":"DEBUG","message":"Replace trace with debug"'
                     );
                     done();
                 });
@@ -136,7 +136,7 @@ describe("Logger", () => {
             describe(`serialize Errors`, () => {
                 it("should add common error fields and error_message if log message is present", (done) => {
                     spyOn(process.stdout,"write").and.callFake(log => {
-                        expect(log).toContain('"v2_message":"Error with log message"');
+                        expect(log).toContain('"message":"Error with log message"');
                         expect(log).toContain('"v2_error_stack":"Error: This is an error');
                         expect(log).toContain('"v2_error_code":"ERR_CODE"');
                         expect(log).toContain('"v2_error_message":"This is an error');
@@ -154,7 +154,7 @@ describe("Logger", () => {
     
                 it("should add common error fields and use Error.message as message if log message is not present", (done) => {
                     spyOn(process.stdout,"write").and.callFake(log => {
-                        expect(log).toContain('"v2_message":"Error without log message"');
+                        expect(log).toContain('"message":"Error without log message"');
                         expect(log).toContain('"v2_error_stack":"Error: Error without log message');
                         expect(log).toContain('"v2_error_code":"ERR_CODE"');
                         expect(log).toContain('"v2_error_file"');
@@ -173,7 +173,7 @@ describe("Logger", () => {
                 it("should add common error fields and use Error.message as message if log message is the Error", (done) => {
                     spyOn(process.stdout,"write").and.callFake(log => {
                         expect(log).toContain('"v2_a":"b"');
-                        expect(log).toContain('"v2_message":"Error as log message"');
+                        expect(log).toContain('"message":"Error as log message"');
                         expect(log).toContain('"v2_error_stack":"Error: Error as log message');
                         expect(log).toContain('"v2_error_code":"ERR_CODE"');
                         expect(log).toContain('"v2_error_file"');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@spreaker/logger",
-    "version": "2.1.1",
+    "version": "3.0.0",
     "description": "Pino-based wrapper with some extra capabilities.",
     "engines": {
         "node": ">=8"

--- a/utils/serializers.js
+++ b/utils/serializers.js
@@ -4,7 +4,7 @@ const parseErrorStack = require("./parseErrorStack");
 /**
  * List of default field that should not be transformed by the serializer
 */
-const whitelist = ["time", "pid"];
+const whitelist = ["time", "pid", "type", "context", "loglevel", "message"];
 
 /**
  * Serializer to transform values into string


### PR DESCRIPTION
In our `Spreaker system` we have some critical fields used, for example, during logs "post processing" or during debug to increase human readability that were affected by the prefix introduction and had broke some assumptions.  
I have analyzed old and new logs for "lamba" (`adserver`) and "not lambda" (`adstitcher`) applications. The result ([logs_analysis.zip](https://github.com/spreaker/pkg-node-logger/files/3783014/logs_analysis.zip)) was that: 
- in the `adserver` the new logs have the same fields but with the `v2_` prefix
- in the `adstitcher` the new logs have 3 fields "duplicated" (`context` and `v2_context`, `type` and `v2_type`, `loglevel` and `v2_loglevel`).

Checking also the way in which the logs are processed by `logstash`, the critical fields used are the same (`context`, `type` and `loglevel`). 
Speaking of debugging it's important that logs have a `message` field instead of a prefixed one, to increase human readability. 
So we decided to add those 4 fields in the whitelist to avoid serialization and prefix addition.