### PR TITLE
Removed obsolete prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Pino-based Logger that we use in all of Spreaker's nodeJS projects. 
 It's possible to create 2 different instances of the logger:
 
-- `Application Logger`: this is an instance of `Pino Logger`, initialized with `Spreaker's base options`, with a custom serializer that take care of stringify objects and array and transforming other types into string before log. All the fields are decorated with a prefix `v2_` to make them recognizables. The `Application Logger` add also a `loglevel` field to each log to have a string version of the log level.
+- `Application Logger`: this is an instance of `Pino Logger`, initialized with `Spreaker's base options`, with a custom serializer that take care of stringify objects and array and transforming other types into string before log. The `Application Logger` add also a `loglevel` field to each log to have a string version of the log level.
 - `Access Logger`: this is an instance of `Pino Logger`, initialized with `Spreaker's base options`.
 
 Both the loggers provide a common functions:
@@ -63,10 +63,10 @@ will produce a log like:
    "context":"app",
    "message":"Stringify log",
    "loglevel":"INFO",
-   "v2_object":"{\"b\":123}",
-   "v2_string":"c",
-   "v2_number":"321",
-   "v2_array":"[\"a\",1,[\"subarray\"]]",
+   "object":"{\"b\":123}",
+   "string":"c",
+   "number":"321",
+   "array":"[\"a\",1,[\"subarray\"]]",
    "v":1
 }
 ```
@@ -112,7 +112,7 @@ will produce a log like:
 ## Errors serializer
 When you pass an error to the logger the possible scenarios are:
 
-- the Error is passed as `mergingObject` (first param) and the log has already a `message` (second param). In this case the logger add field `"v2_error_message": Error.message` and [common error fields](#common-error-fields) to the `mergingObject` and the log message is printed in the `message` field
+- the Error is passed as `mergingObject` (first param) and the log has already a `message` (second param). In this case the logger add field `"error_message": Error.message` and [common error fields](#common-error-fields) to the `mergingObject` and the log message is printed in the `message` field
 ```js
 logger.error(new Error("This is an error"), "Error with log message");
 ```
@@ -125,10 +125,10 @@ will produce a log like:
    "context":"app",
    "loglevel":"ERROR",
    "message":"Error with log message",
-   "v2_error_message":"This is an error",
-   "v2_error_stack":"Error: This is an error...",
-   "v2_error_file":"...",
-   "v2_error_line":"...",
+   "error_message":"This is an error",
+   "error_stack":"Error: This is an error...",
+   "error_file":"...",
+   "error_line":"...",
    "v":1
 }
 ```
@@ -146,9 +146,9 @@ will produce a log like:
    "context":"app",
    "loglevel":"ERROR",
    "message":"Error without log message",
-   "v2_error_stack":"Error: Error without log message...",
-   "v2_error_file":"...",
-   "v2_error_line":"...",
+   "error_stack":"Error: Error without log message...",
+   "error_file":"...",
+   "error_line":"...",
    "v":1
 }
 ```
@@ -167,10 +167,10 @@ will produce a log like:
    "context":"app",
    "loglevel":"ERROR",
    "message":"Error as log message",
-   "v2_a":"b",
-   "v2_error_stack":"Error: Error as log message...",
-   "v2_error_file":"...",
-   "v2_error_line":"...",
+   "a":"b",
+   "error_stack":"Error: Error as log message...",
+   "error_file":"...",
+   "error_line":"...",
    "v":1
 }
 ```
@@ -179,10 +179,10 @@ will produce a log like:
 In application logs
 ```js
 {
-    v2_error_stack: "error stack trace",
-    v2_error_code: "error code property",
-    v2_error_file: "path of the file",
-    v2_error_line: "number of the line"
+    error_stack: "error stack trace",
+    error_code: "error code property",
+    error_file: "path of the file",
+    error_line: "number of the line"
 }
 ```
 or in access logs

--- a/index_spec.js
+++ b/index_spec.js
@@ -32,20 +32,10 @@ describe("Logger", () => {
                 }
                 return logger;
             }
-            it("should add 'v2_' prefix to all the fields, except for the whitelisted ones", (done) => {
-                spyOn(process.stdout,"write").and.callFake(log => {
-                    expect(log).toContain(
-                        '"type":"test","context":"app","time":123,"pid":"321","loglevel":"INFO","message":"Add prefix","v2_toPrefix":"field to be prefixed"'
-                    );
-                    done();
-                });
-                const logger = getLogger();
-                logger.info({"time":123,"pid":"321","toPrefix":"field to be prefixed"}, "Add prefix");
-            });
             it("should log the initial properties passed", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain(
-                        '"type":"test","context":"app","loglevel":"INFO","message":"Initial properties","v2_test":"initial_properties"'
+                        '"type":"test","context":"app","test":"initial_properties","loglevel":"INFO","message":"Initial properties"'
                     );
                     done();
                 });
@@ -65,7 +55,7 @@ describe("Logger", () => {
             it("should stringify objects or array and transform other types into string before log INFO", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain(
-                        '"v2_test":"stringify_info","v2_object":"{\\\"b\\\":123}","v2_string":"c","v2_number":"321","v2_array":"[\\\"a\\\",1,[\\\"subarray\\\"]]"'
+                        '"test":"stringify_info","object":"{\\\"b\\\":123}","string":"c","number":"321","array":"[\\\"a\\\",1,[\\\"subarray\\\"]]"'
                     );
                     done();
                 });
@@ -75,7 +65,7 @@ describe("Logger", () => {
             it("should stringify objects or array and transform other types into string before log WARN", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain(
-                        '"v2_test":"stringify_warn","v2_object":"{\\\"b\\\":123}","v2_string":"c","v2_number":"321","v2_array":"[\\\"a\\\",1,[\\\"subarray\\\"]]"'
+                        '"test":"stringify_warn","object":"{\\\"b\\\":123}","string":"c","number":"321","array":"[\\\"a\\\",1,[\\\"subarray\\\"]]"'
                     );
                     done();
                 });
@@ -85,7 +75,7 @@ describe("Logger", () => {
             it("should transform null or boolean fields into string", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain(
-                        '"v2_test":"stringify_null","v2_a":"null","v2_b":"true"'
+                        '"test":"stringify_null","a":"null","b":"true"'
                     );
                     done();
                 });
@@ -95,7 +85,7 @@ describe("Logger", () => {
             it("should stringify functions", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain(
-                        '"v2_test":"stringify_functions","v2_function":"function () {return true}"'
+                        '"test":"stringify_functions","function":"function () {return true}"'
                     );
                     done();
                 });
@@ -115,7 +105,7 @@ describe("Logger", () => {
             it("should add the correct loglevel string if mergingObject is passed", (done) => {
                 spyOn(process.stdout,"write").and.callFake(log => {
                     expect(log).toContain(
-                        '"type":"test","context":"app","loglevel":"WARN","message":"Loglevel with mergingObject","v2_a":"b"'
+                        '"type":"test","context":"app","a":"b","loglevel":"WARN","message":"Loglevel with mergingObject"'
                     );
                     done();
                 });
@@ -137,12 +127,11 @@ describe("Logger", () => {
                 it("should add common error fields and error_message if log message is present", (done) => {
                     spyOn(process.stdout,"write").and.callFake(log => {
                         expect(log).toContain('"message":"Error with log message"');
-                        expect(log).toContain('"v2_error_stack":"Error: This is an error');
-                        expect(log).toContain('"v2_error_code":"ERR_CODE"');
-                        expect(log).toContain('"v2_error_message":"This is an error');
-                        expect(log).toContain('"v2_error_file"');
-                        expect(log).toContain('"v2_error_line"');
-                        expect(log).not.toContain('"v2_stack"');
+                        expect(log).toContain('"error_stack":"Error: This is an error');
+                        expect(log).toContain('"error_code":"ERR_CODE"');
+                        expect(log).toContain('"error_message":"This is an error');
+                        expect(log).toContain('"error_file"');
+                        expect(log).toContain('"error_line"');
                         expect(log).not.toContain('"stack"');
                         done();
                     });
@@ -155,12 +144,11 @@ describe("Logger", () => {
                 it("should add common error fields and use Error.message as message if log message is not present", (done) => {
                     spyOn(process.stdout,"write").and.callFake(log => {
                         expect(log).toContain('"message":"Error without log message"');
-                        expect(log).toContain('"v2_error_stack":"Error: Error without log message');
-                        expect(log).toContain('"v2_error_code":"ERR_CODE"');
-                        expect(log).toContain('"v2_error_file"');
-                        expect(log).toContain('"v2_error_line"');
+                        expect(log).toContain('"error_stack":"Error: Error without log message');
+                        expect(log).toContain('"error_code":"ERR_CODE"');
+                        expect(log).toContain('"error_file"');
+                        expect(log).toContain('"error_line"');
                         expect(log).not.toContain('"error_message"');
-                        expect(log).not.toContain('"v2_stack"');
                         expect(log).not.toContain('"stack"');
                         done();
                     });
@@ -172,14 +160,13 @@ describe("Logger", () => {
     
                 it("should add common error fields and use Error.message as message if log message is the Error", (done) => {
                     spyOn(process.stdout,"write").and.callFake(log => {
-                        expect(log).toContain('"v2_a":"b"');
+                        expect(log).toContain('"a":"b"');
                         expect(log).toContain('"message":"Error as log message"');
-                        expect(log).toContain('"v2_error_stack":"Error: Error as log message');
-                        expect(log).toContain('"v2_error_code":"ERR_CODE"');
-                        expect(log).toContain('"v2_error_file"');
-                        expect(log).toContain('"v2_error_line"');
-                        expect(log).not.toContain('"v2_error_message"');
-                        expect(log).not.toContain('"v2_stack"');
+                        expect(log).toContain('"error_stack":"Error: Error as log message');
+                        expect(log).toContain('"error_code":"ERR_CODE"');
+                        expect(log).toContain('"error_file"');
+                        expect(log).toContain('"error_line"');
+                        expect(log).not.toContain('"error_message"');
                         expect(log).not.toContain('"stack"');
                         done();
                     });
@@ -191,12 +178,11 @@ describe("Logger", () => {
                 
                 it("should not add error code if not present in Error instance", (done) => {
                     spyOn(process.stdout,"write").and.callFake(log => {
-                        expect(log).toContain('"v2_error_stack":"Error: Error without code');
-                        expect(log).toContain('"v2_error_file"');
-                        expect(log).toContain('"v2_error_line"');
-                        expect(log).not.toContain('"v2_error_message"');
-                        expect(log).not.toContain('"v2_error_code"');
-                        expect(log).not.toContain('"v2_stack"');
+                        expect(log).toContain('"error_stack":"Error: Error without code');
+                        expect(log).toContain('"error_file"');
+                        expect(log).toContain('"error_line"');
+                        expect(log).not.toContain('"error_message"');
+                        expect(log).not.toContain('"error_code"');
                         expect(log).not.toContain('"stack"');
                         done();
                     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@spreaker/logger",
-    "version": "2.0.0",
+    "version": "4.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@spreaker/logger",
-    "version": "3.0.0",
+    "version": "4.0.0",
     "description": "Pino-based wrapper with some extra capabilities.",
     "engines": {
         "node": ">=8"

--- a/utils/serializers.js
+++ b/utils/serializers.js
@@ -11,18 +11,13 @@ const whitelist = ["time", "pid", "type", "context", "loglevel", "message"];
 */
 const serializeToString = (key, obj) => {
     if (whitelist.indexOf(key) === -1) {
-        // we create a new key with "v2_" prefix to recognize field serialized
-        // and avoid collision with old keys not serialized
-        const newKey = `v2_${key}`;
         // Try to stringify objects/array or transform other types in string
         try {
             if (typeof obj[key] === "object" || obj[key] instanceof Array) {
-                obj[newKey] = JSON.stringify(obj[key]);
+                obj[key] = JSON.stringify(obj[key]);
             } else {
-                obj[newKey] = String(obj[key]);
+                obj[key] = String(obj[key]);
             }
-            // if the process goes well we delete the not serialized key
-            delete obj[key];
         } 
         // in case of errors just return the current value
         catch(err) {


### PR DESCRIPTION
I'm getting rid of the v2 prefix since it became obsolete after the migration to the new ELK stack.